### PR TITLE
fixed: creating a newEnv with value=0 and type=Int throws ERR_NEED_NOT_NULL

### DIFF
--- a/src/helpers/Checker.ts
+++ b/src/helpers/Checker.ts
@@ -70,6 +70,24 @@ class Checker {
   }
 
   /**
+   * Check if the given value/object is **NOT** `null` nor `undefined`, then throw if not
+   *
+   * @param obj - The first object to compare.
+   * @param name - A name to include in the error message.
+   * @throws Error - If the given value is either `null` or `undefined`
+   * @returns
+   *
+   * @public
+   */
+  isDefined(obj: any, name: string = ''): boolean {
+    if (obj === undefined || obj === null) {
+      return this.send(`ERR_NEED_DEFINED_OBJ ${name})`);
+    }
+
+    return true;
+  }
+
+  /**
    * Verify if an object is defined, then throw if not
    *
    * @param obj - The object to verify

--- a/src/helpers/Env.ts
+++ b/src/helpers/Env.ts
@@ -153,7 +153,7 @@ class Env {
     value = data.parseType(parseType);
 
     if (parseType !== 'Bool') {
-      checker.isExists(value, name);
+      checker.isDefined(value, name);
     }
     if (allow) {
       checker.isIn(allow, value, name);


### PR DESCRIPTION
Created a new isDefined() method in checker that checks if a value is **not** `null` nor `undefined` instead of testing if it is falsy. 

It's a quickfix, I didn't do any further investigation to see if `Checker.isExists()` have been used for a similar purpose elswhere.

I'm in a rush for now :)