### PR TITLE
New Feature: injectable logger

### DIFF
--- a/src/helpers/depreciate.ts
+++ b/src/helpers/depreciate.ts
@@ -20,7 +20,7 @@ let deprecateLogger: DeprecationLogger = {
 /**
  * Change the default logger (console) by a custom logger.
  *
- * @param {object} logger - A logger to replace console. The only requirement is
+ * @param logger - A logger to replace console. The only requirement is
  * that it must implement a warn method.
  */
 export function setLogger(logger: DeprecationLogger) {

--- a/src/helpers/depreciate.ts
+++ b/src/helpers/depreciate.ts
@@ -1,6 +1,40 @@
 import e from '../security/env.js';
 import debugMode from './debugMode.js';
 
+// #region Types
+
+interface DeprecationLogger{
+  warn(msg: string, ...data:any): void;
+}
+
+// #endregion Types
+
+/**
+ * A simple logger using console when the logger have not been set.
+ */
+let deprecateLogger: DeprecationLogger = {
+  // eslint-disable-next-line no-console
+  warn: console.warn,
+};
+
+/**
+ * Change the default logger (console) by a custom logger.
+ *
+ * @param {object} logger - A logger to replace console. The only requirement is
+ * that it must implement a warn method.
+ */
+export function setLogger(logger: DeprecationLogger) {
+  if (!logger || (logger && typeof logger !== 'object')) {
+    throw new Error('The given logger must be an object.');
+  }
+
+  if (typeof logger.warn !== 'function') {
+    throw new Error('logger.warn must be a function !');
+  }
+
+  deprecateLogger = logger;
+}
+
 /**
  * Print a depreciated warning to the console
  *
@@ -11,8 +45,7 @@ import debugMode from './debugMode.js';
  */
 const depreciate = function warnAboutDepreciateCalledMethod(oldMethod: string, newMethod: string) {
   if (e.APP_ENV !== 'production' && debugMode()) {
-    console.warn(`@Depreciated method "${oldMethod}"called`); // eslint-disable-line no-console
-    console.warn(`It has to be replace by: ${newMethod}`); // eslint-disable-line no-console
+    deprecateLogger.warn(`@Deprecated method "${oldMethod}" called. It must to be replaced by "${newMethod}".`);
   }
 };
 

--- a/src/helpers/depreciate.ts
+++ b/src/helpers/depreciate.ts
@@ -3,7 +3,7 @@ import debugMode from './debugMode.js';
 
 // #region Types
 
-interface DeprecationLogger{
+interface DeprecationLogger {
   warn(msg: string, ...data:any): void;
 }
 


### PR DESCRIPTION
To let a way for the `subito-lib` consumer to decide what to do with depecration warning, I added a way to inject a logger with a minimal interface. By default, the module still use `console`.  